### PR TITLE
Add VS Code support, Windows batch scripts, & move PDF theme settings to index.adoc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "asciidoc.use_asciidoctorpdf": true,
+    "asciidoc.preview.useEditorStyle": false,
+    "asciidoc.preview.style": "book/themes/"
+}

--- a/book/chapter-03-How-Planet-Systems-Work/content.adoc
+++ b/book/chapter-03-How-Planet-Systems-Work/content.adoc
@@ -1,4 +1,7 @@
+:imagesdir: images
+ifeval::["{docname}" == "index"]
 :imagesdir: chapter-03-How-Planet-Systems-Work/images
+endif::[]
 
 = How planet systems work?
 

--- a/book/index.adoc
+++ b/book/index.adoc
@@ -18,6 +18,9 @@
 :description: HTML meta tag content for description
 :keywords: HTML meta tag content for keywords
 :icons: font
+:pdf-themesdir: {docdir}/themes
+:pdf-fontsdir: {docdir}/fonts
+:pdf-theme: basic
 :pdfmark: true
 :imagesdir: ./images
 :xrefstyle: short

--- a/create-book-epub.bat
+++ b/create-book-epub.bat
@@ -1,0 +1,9 @@
+REM Docker image: https://hub.docker.com/r/asciidoctor/docker-asciidoctor
+REM Docker image repository: https://github.com/asciidoctor/docker-asciidoctor
+
+REM The directory where the book source is located
+SET BOOK_SOURCE_DIR=book
+REM The directory where the book's generated output files will be created
+SET BOOK_BUILD_DIR=build
+
+docker run --rm -v "%CD%":/documents/ asciidoctor/docker-asciidoctor asciidoctor-epub3 -D %BOOK_BUILD_DIR% %BOOK_SOURCE_DIR%/index.adoc

--- a/create-book-epub.sh
+++ b/create-book-epub.sh
@@ -7,6 +7,6 @@ BOOK_SOURCE_DIR=book
 # The directory where the book's generated output files will be created
 BOOK_BUILD_DIR=build
 
-docker run --rm -v $(pwd)/book:/documents/ asciidoctor/docker-asciidoctor asciidoctor-epub3 \
+docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-epub3 \
     -D $BOOK_BUILD_DIR \
     $BOOK_SOURCE_DIR/index.adoc

--- a/create-book-pdf.bat
+++ b/create-book-pdf.bat
@@ -1,0 +1,8 @@
+REM Docker image: https://hub.docker.com/r/asciidoctor/docker-asciidoctor
+REM Docker image repository: https://github.com/asciidoctor/docker-asciidoctor
+REM The directory where the book source is located
+SET BOOK_SOURCE_DIR=book
+REM The directory where the book's generated output files will be created
+SET BOOK_BUILD_DIR=build
+
+docker run --rm -v "%CD%":/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf -D %BOOK_BUILD_DIR% %BOOK_SOURCE_DIR%/index.adoc

--- a/create-book-pdf.sh
+++ b/create-book-pdf.sh
@@ -8,8 +8,5 @@ BOOK_SOURCE_DIR=book
 BOOK_BUILD_DIR=build
 
 docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf \
-    -a pdf-themesdir=$BOOK_SOURCE_DIR/themes \
-    -a pdf-theme=$1 \
-    -a pdf-fontsdir=$BOOK_SOURCE_DIR/fonts \
     -D $BOOK_BUILD_DIR \
     $BOOK_SOURCE_DIR/index.adoc

--- a/create-book-pdf.sh
+++ b/create-book-pdf.sh
@@ -6,7 +6,11 @@
 BOOK_SOURCE_DIR=book
 # The directory where the book's generated output files will be created
 BOOK_BUILD_DIR=build
-
+#     To override theme configuration file you can pass the following command-line arguments:
+#
+#    -a pdf-themesdir=$BOOK_SOURCE_DIR/themes \
+#    -a pdf-theme=$1 \
+#    -a pdf-fontsdir=$BOOK_SOURCE_DIR/fonts \
 docker run --rm -v $(pwd):/documents/ asciidoctor/docker-asciidoctor asciidoctor-pdf \
     -D $BOOK_BUILD_DIR \
     $BOOK_SOURCE_DIR/index.adoc

--- a/interactive-asciidoctor-shell.bat
+++ b/interactive-asciidoctor-shell.bat
@@ -1,0 +1,4 @@
+REM Docker image: https://hub.docker.com/r/asciidoctor/docker-asciidoctor
+REM Docker image repository: https://github.com/asciidoctor/docker-asciidoctor
+
+docker run -it -v "%CD%/book":/documents/ asciidoctor/docker-asciidoctor


### PR DESCRIPTION
These changes do the following:
- Add a VS Code settings file (preview better matches the theme)
- Add batch script equivalents of the *.sh scripts for Windows users
- Move PDF settings into index.adoc (simplifies the command line needed to build)